### PR TITLE
feat:epoll.del実装

### DIFF
--- a/src/EpollUtils.cpp
+++ b/src/EpollUtils.cpp
@@ -40,9 +40,11 @@ bool EpollUtils::mod(int fd, EpollContext* ctx, uint32_t events) {
 }
 
 bool EpollUtils::del(int fd) {
-  // 別PR
-  (void)fd;
-  return false;
+  if (epoll_ctl(_epoll_fd, EPOLL_CTL_DEL, fd, NULL) < 0) {
+    perror("epoll_ctl: del");
+    return false;
+  }
+  return true;
 }
 
 int EpollUtils::wait(struct epoll_event* events, int max_events,

--- a/test/test_epoll_del.cpp
+++ b/test/test_epoll_del.cpp
@@ -1,0 +1,109 @@
+#include <sys/epoll.h>  // EPOLLIN
+#include <unistd.h>     // pipe, close
+#include <cstdio>       // perror
+#include <cstdlib>
+#include <iostream>
+#include "../inc/EpollContext.hpp"
+#include "../inc/EpollUtils.hpp"
+
+// 色付け用
+#define GREEN "\033[32m"
+#define RED "\033[31m"
+#define RESET "\033[0m"
+
+void printResult(const std::string& testName, bool success) {
+  if (success) {
+    std::cout << GREEN << "[PASS] " << testName << RESET << std::endl;
+  } else {
+    std::cout << RED << "[FAIL] " << testName << RESET << std::endl;
+    std::exit(1);
+  }
+}
+
+int main() {
+  std::cout << "=== Starting EpollUtils::del Unit Test ===" << std::endl;
+
+  try {
+    EpollUtils epoll;
+    std::cout << "EpollUtils created successfully." << std::endl;
+
+    // テスト用のFDを用意 (pipeを使用)
+    int pipe_fds[2];
+    if (pipe(pipe_fds) < 0) {
+      perror("pipe");
+      return 1;
+    }
+
+    // Context作成
+    EpollContext* ctx = EpollContext::createListener(8080);
+
+    // ---------------------------------------------------------
+    // 準備: まず add で登録
+    // ---------------------------------------------------------
+    {
+      bool ret = epoll.add(pipe_fds[0], ctx, EPOLLIN);
+      printResult("Setup: Add FD with EPOLLIN", ret == true);
+    }
+
+    // ---------------------------------------------------------
+    // TEST 1: 正常な削除
+    // ---------------------------------------------------------
+    {
+      bool ret = epoll.del(pipe_fds[0]);
+      printResult("Del: Remove registered FD", ret == true);
+    }
+
+    // ---------------------------------------------------------
+    // TEST 2: 同じFDを再度削除 (既に削除済みなのでエラー)
+    // ---------------------------------------------------------
+    {
+      std::cout << "--- Expecting 'No such file or directory' error below ---"
+                << std::endl;
+      bool ret = epoll.del(pipe_fds[0]);
+      printResult("Del: Already removed FD (should fail)", ret == false);
+    }
+
+    // ---------------------------------------------------------
+    // TEST 3: 未登録のFDを削除 (エラーになるはず)
+    // ---------------------------------------------------------
+    {
+      std::cout << "--- Expecting 'No such file or directory' error below ---"
+                << std::endl;
+      bool ret = epoll.del(pipe_fds[1]);  // pipe_fds[1]は未登録
+      printResult("Del: Unregistered FD (should fail)", ret == false);
+    }
+
+    // ---------------------------------------------------------
+    // TEST 4: 無効なFDを削除 (エラーになるはず)
+    // ---------------------------------------------------------
+    {
+      std::cout << "--- Expecting 'Bad file descriptor' error below ---"
+                << std::endl;
+      bool ret = epoll.del(-1);
+      printResult("Del: Invalid FD (should fail)", ret == false);
+    }
+
+    // ---------------------------------------------------------
+    // TEST 5: 削除後に再登録できるか確認
+    // ---------------------------------------------------------
+    {
+      bool ret = epoll.add(pipe_fds[0], ctx, EPOLLIN);
+      printResult("Re-add: Add FD after del", ret == true);
+
+      ret = epoll.del(pipe_fds[0]);
+      printResult("Del: Remove re-added FD", ret == true);
+    }
+
+    // 後始末
+    delete ctx;
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+
+  } catch (const std::exception& e) {
+    std::cerr << RED << "[FATAL] Exception: " << e.what() << RESET << std::endl;
+    return 1;
+  }
+
+  std::cout << "=== All Tests Passed ===" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
```
➜  webserv git:(63-epoll-epollutilsdel) ✗ ./test_epoll_del
=== Starting EpollUtils::del Unit Test ===
EpollUtils created successfully.
[PASS] Setup: Add FD with EPOLLIN
[PASS] Del: Remove registered FD
--- Expecting 'No such file or directory' error below ---
epoll_ctl: del: No such file or directory
[PASS] Del: Already removed FD (should fail)
--- Expecting 'No such file or directory' error below ---
epoll_ctl: del: No such file or directory
[PASS] Del: Unregistered FD (should fail)
--- Expecting 'Bad file descriptor' error below ---
epoll_ctl: del: Bad file descriptor
[PASS] Del: Invalid FD (should fail)
[PASS] Re-add: Add FD after del
[PASS] Del: Remove re-added FD
=== All Tests Passed ===
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * ファイルディスクリプタの削除機能を実装しました。正常な削除時は成功を返し、エラー時は失敗を返します。

* **テスト**
  * 削除機能のユニットテストを追加しました。正常系および異常系の動作検証を含みます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->